### PR TITLE
Update dictionary version info

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PHES.ODM.Doc
 Type: Package
 Title: PHES-ODM-Doc
-Version: 0.1.0
+Version: 2.0.1
 Authors@R: c(
     person(given = "Yulric", family = "Sequeira", role = c("aut"), email = "ysequeira@ohri.ca"),
     person(given = "Rostyslav", family = "Vyuha", role = c("aut","cre"), email = "rvyuha@toh.ca"))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PHES.ODM.Doc
 Type: Package
 Title: PHES-ODM-Doc
-Version: 2.0.1
+Version: 0.1.0
 Authors@R: c(
     person(given = "Yulric", family = "Sequeira", role = c("aut"), email = "ysequeira@ohri.ca"),
     person(given = "Rostyslav", family = "Vyuha", role = c("aut","cre"), email = "rvyuha@toh.ca"))

--- a/qmd/_quarto.yml
+++ b/qmd/_quarto.yml
@@ -4,8 +4,10 @@ project:
 
 book:
   title: "Public Health Environmental Surveillance Open Data Model (PHES-ODM) Documentation"
+  output-file: "ODM-documentation-v2.0.1"
   version: "2.0.1"
-  #subtitle: 
+  subtitle: |
+      Dictionary v2.0.0. <br>Documentation V2.0.1.
   date: last-modified
   date-format: iso
   license: CC 4.0 BY-SA
@@ -33,7 +35,7 @@ book:
   page-footer:
     left: |
       #Dictionary v2.0.0<br>Documentation V2.0.1
-
+      
 format:
   html:
     toc: true
@@ -42,14 +44,10 @@ format:
     code-copy: true
     code-overflow: wrap
     lang: en-ca
-    use_issues_button: true
-    use_repository_button: true
-
   pdf:
     documentclass: scrbook
     toc: true
     number-sections: true
     colorlinks: true
-    
   epub:
     css: ./assets/phes-odm.css

--- a/qmd/index.qmd
+++ b/qmd/index.qmd
@@ -5,9 +5,6 @@ project:
 ```{r setup, echo=FALSE}
 knitr::opts_knit$set(root.dir = normalizePath("../"))
 ```
-{{< include _dictionary-version.qmd >}} 
-Documention v{{< meta book.version >}}.
-
 # Introduction {.unnumbered}
 
 > Facilitating the Collection and Sharing of High-Quality, Interoperable Environmental Surveillance Data: A Community Open Science Project. 


### PR DESCRIPTION
1) Change the document output file name to 'ODM-documentation-{version}. This is the file name approach for ODM.
2) Move version information to the title page. (Better for the PDF and EPUB versions).

Putting code and variables into the YAML isn't quite working for Quarto, it appears. We can manually update the version info until we use variables and metadata. Well, we can probably modify using `project scripts`, but it seems like other, easier solutions will be available shortly. https://github.com/quarto-dev/quarto-cli/discussions/606#discussioncomment-2553877

