### PR TITLE
Fix case-sensitive mismatch dropping PK/FK columns from table docs

### DIFF
--- a/R/parts-sheet.R
+++ b/R/parts-sheet.R
@@ -94,8 +94,8 @@ table_column_metadata = list(
   table = list(
     name = "{table_name}",
     categories = list(
-      primary_key = "pk",
-      foreign_key = "fk",
+      primary_key = "pK",
+      foreign_key = "fK",
       header = "header",
       input = "input"
     )


### PR DESCRIPTION
table_column_metadata used lowercase "pk"/"fk" role markers, but the dictionary source data (ODM_parts.csv / ODM_dictionary xlsx) uses "pK"/"fK". Since R's == is case-sensitive, every primary and foreign key column failed to match the filter in tables.qmd and was silently dropped from each table's rendered header list, leaving only header-role columns.